### PR TITLE
Implement standard deviation for tables only

### DIFF
--- a/client/app/controllers/jiffController.js
+++ b/client/app/controllers/jiffController.js
@@ -68,7 +68,7 @@ define(['mpc', 'pki', 'BigNumber', 'jiff', 'jiff_bignumber', 'jiff_restAPI', 'ta
     };
     baseOptions = Object.assign(baseOptions, options);
     baseOptions.hooks = Object.assign({}, baseOptions.hooks, cryptoHooks);
-    var bigNumberOptions = { Zp: '36893488147419103183' }; // 2^65-49
+    var bigNumberOptions = { Zp: '618970019642690137449562111' }; // 2^89-1
 
     var restOptions = {
       flushInterval: 0,
@@ -116,9 +116,13 @@ define(['mpc', 'pki', 'BigNumber', 'jiff', 'jiff_bignumber', 'jiff_restAPI', 'ta
       jiff.restReceive = function () {
         jiff.disconnect(false, false);
         callback.apply(null, arguments);
-      }
+      };
       for (var i = 0; i < values.length; i++) {
         jiff.share(values[i], null, [1, 's1'], [jiff.id]);
+        // Share the square of the input for standard deviation: only for tables, but not for questions
+        if (i < ordering.tables.length) {
+          jiff.share(new BigNumber(values[i]).pow(2), null, [1, 's1'], [jiff.id]);
+        }
       }
       jiff.restFlush();
     });

--- a/client/app/controllers/tableController.js
+++ b/client/app/controllers/tableController.js
@@ -918,7 +918,7 @@ define(['jquery', 'Handsontable', 'table_template', 'filesaver', 'alertify', 'qt
     return {sums, NaNs}
   }
 
-  function saveTables(tables, session) {
+  function saveTables(tables, session, title) {
 
     var tables_csv = [];
 
@@ -934,8 +934,7 @@ define(['jquery', 'Handsontable', 'table_template', 'filesaver', 'alertify', 'qt
     }
 
     tables_csv = tables_csv.join('\n\n\n');
-    filesaver.saveAs(new Blob([tables_csv], {type: 'text/plain;charset=utf-8'}), 'Aggregate_Data_' + session + '.csv');
-
+    filesaver.saveAs(new Blob([tables_csv], {type: 'text/plain;charset=utf-8'}), 'Aggregate_' + title + '_' + session + '.csv');
   }
 
   function getHeaderWidth(table) {

--- a/client/app/helper/mpc.js
+++ b/client/app/helper/mpc.js
@@ -57,22 +57,46 @@ define([], function () {
     var shares = [];
     for (var k = 0; k < ordering.tables.length + ordering.questions.length; k++) {
       var subid = submitters[0];
+
       var entry_sum = jiff_instance.share(null, null, [1, 's1'], [subid]);
       entry_sum = entry_sum[subid];
+
+      // Standard deviation is only computed under MPC for tables
+      var entry_squares_sum;
+      if (k < ordering.tables.length) {
+        entry_squares_sum = jiff_instance.share(null, null, [1, 's1'], [subid]);
+        entry_squares_sum = entry_squares_sum[subid];
+      }
 
       for (var p = 1; p < submitters.length; p++) {
         subid = submitters[p];
 
         var single_share = jiff_instance.share(null, null, [1, 's1'], [subid]);
         single_share = single_share[subid];
-
         entry_sum = entry_sum.sadd(single_share);
+
+        if (k < ordering.tables.length) {
+          var single_square = jiff_instance.share(null, null, [1, 's1'], [subid]);
+          single_square = single_square[subid];
+          entry_squares_sum = entry_squares_sum.sadd(single_square);
+        }
       }
 
       var promise = jiff_instance.open(entry_sum, [1]);
-      if (jiff_instance.id === 1) {
-        shares.push(promise);
+
+      // For entries in the table, we return a promise to an object
+      //    { sum: <sum of inputs>, squaresSum: <sum of squared inputs> }
+      // For questions, we return a promise to a single sum/number corresponding to an option
+      if (k < ordering.tables.length) {
+        var promise2 = jiff_instance.open(entry_squares_sum, [1]);
+        if (jiff_instance.id === 1) {
+          promise = Promise.all([promise, promise2]).then(function (results) {
+            return { sum: results[0], squaresSum: results[1]};
+          });
+        }
       }
+
+      shares.push(promise);
     }
 
     return Promise.all(shares);
@@ -91,37 +115,48 @@ define([], function () {
   //   }
   var format = function (resultsPromise, submitters, ordering) {
     return resultsPromise.then(function (results) {
-      var finalObject = {}; // results array will be transformed to an object of the correct form
+      var averages = {}; // results array will be transformed to an object of the correct form
+      var questions = {};
+      var deviations = {};
       for (var i = 0; i < ordering.tables.length; i++) {
         var table = ordering.tables[i].table;
         var row = ordering.tables[i].row;
         var col = ordering.tables[i].col;
 
-        results[i] = results[i].div(submitters.length);
-        results[i] = results[i].toFixed(2); // returns a string, with 2 digits after decimal
-        if (finalObject[table] == null) {
-          finalObject[table] = {};
+        // Compute mean/average
+        var mean = results[i].sum;
+        mean = mean.div(submitters.length);
+
+        // Compute standard deviation
+        var deviation = results[i].squaresSum;
+        deviation = deviation.div(submitters.length);
+        deviation = deviation.minus(mean.pow(2));
+        deviation = deviation.sqrt();
+
+        if (averages[table] == null) {
+          averages[table] = {};
+          deviations[table] = {};
         }
-        if (finalObject[table][row] == null) {
-          finalObject[table][row] = {};
+        if (averages[table][row] == null) {
+          averages[table][row] = {};
+          deviations[table][row] = {};
         }
-        finalObject[table][row][col] = results[i];
+        averages[table][row][col] = mean.toFixed(2); // returns a string, with 2 digits after decimal
+        deviations[table][row][col] = deviation.toFixed(2);
       }
 
+      // format questions as questions[<question>][<option>] = count of parties that choose this option
       for (var j = 0; j < ordering.questions.length; j++) {
         var question = ordering.questions[j].question;
         var label = ordering.questions[j].label;
 
-        if (finalObject['questions'] == null) {
-          finalObject['questions'] = {};
+        if (questions[question] == null) {
+          questions[question] = {};
         }
-        if (finalObject['questions'][question] == null) {
-          finalObject['questions'][question] = {};
-        }
-        finalObject['questions'][question][label] = results[i+j].toString();
+        questions[question][label] = results[i+j].toString();
       }
 
-      return finalObject;
+      return { averages: averages, questions: questions, deviations: deviations };
     });
   };
 

--- a/client/app/views/unmaskView.js
+++ b/client/app/views/unmaskView.js
@@ -26,17 +26,24 @@ define(['jquery', 'controllers/jiffController', 'controllers/tableController', '
           var privateKey = e.target.result;
 
           jiffController.analyst.computeAndFormat(sessionKey, sessionPass, privateKey, error, function (result) {
-            var questions = result['questions'];
-            delete result['questions'];
+            var questions = result.questions;
 
-            tableController.createTableElems(table_template.tables, '#tables-area');
-            tableController.saveTables(result, sessionKey);
+            // for tables only
+            var averages = result.averages;
+            var deviations = result.deviations;
+
+
+            // download averages and deviations
+            tableController.saveTables(averages, sessionKey, 'Averages');
+            tableController.saveTables(deviations, sessionKey, 'Standard_Deviations');
             if (questions != null) {
               tableController.saveQuestions(questions, sessionKey);
             }
 
+            // Only display averages in the table
+            tableController.createTableElems(table_template.tables, '#tables-area');
+            tableController.displayReadTable(averages);
             $('#tables-area').show();
-            tableController.displayReadTable(result);
           });
         });
       }

--- a/server/jiff/create.js
+++ b/server/jiff/create.js
@@ -28,7 +28,7 @@ const cryptoHooks =  {
 const options = { logs: true, sodium: false, hooks: {} };
 const computeOptions = {
   sodium: false,
-  Zp: '36893488147419103183',
+  Zp: '618970019642690137449562111',  // 2^89-1
   hooks: {
     createSecretShare: [function (jiff, share) {
       share.refresh = function () {


### PR DESCRIPTION
Implement standard deviation under MPC, only for values inside the tables, but not questions.

This uses the following equality:
Variance (X) = E[X^2] - (E[X])^2
                     = Sum (X^2_i) - (Sum X_i)^2
                        --------------    ----------------
                              n                    n


Workflow:
1. clients share their inputs as before, but shares the square of any table-based input right after the input.
2. Server/analyst computation: also as before, but produces the sum of the squared shared inputs as well as the original inputs.
3. Analyst formatting: code computes the average for every entry in the table, then computes the average of the squares, and subtract the average squared from it. We perform square root at the end to get standard deviation from variance.
4. Analyst output: in addition to the averages and questions CSV files, we get a third CSV file in the same format as the averages one but for standard deviation.

Note: increased Zp to 2^89-1 (~= 600000000000000000000000000 ~= 6 * 10^26)